### PR TITLE
Add SQLITE_HAS_COLUMN_METADATA=yes in GDAL_SPATIALITE section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1495,6 +1495,7 @@ gdal-optfile:
 !IFDEF GDAL_SPATIALITE
     echo SQLITE_INC=-I$(OUTPUT_DIR)\include -DHAVE_SPATIALITE -DSPATIALITE_AMALGAMATION >> $(OUTPUT_DIR)\gdal.opt
     echo SQLITE_LIB=$(OUTPUT_DIR)\lib\sqlite3_i.lib $(OUTPUT_DIR)\lib\spatialite_i.lib >> $(OUTPUT_DIR)\gdal.opt
+    echo SQLITE_HAS_COLUMN_METADATA=yes >> $(OUTPUT_DIR)\gdal.opt
 	echo $(SQLITE_DIR) >> $(OUTPUT_DIR)\doc\gdal_deps.txt
     echo $(SPATIALITE_DIR) >> $(OUTPUT_DIR)\doc\gdal_deps.txt
 !ENDIF


### PR DESCRIPTION
Support for it was added in the GDAL_SQLITE section per
https://github.com/gisinternals/buildsystem/commit/40886392a626e7f4dcc4ac2946b59bac3bc904df
but this section isn't actually used, so we need it in GDAL_SPATIALITE

This will fix https://trac.osgeo.org/gdal/ticket/7007