### PR TITLE
Disable running MSVC 2013 development builds

### DIFF
--- a/makevc12.bat
+++ b/makevc12.bat
@@ -156,7 +156,7 @@ set msautotest-dir=msautotest
 set pkg-version=gdal-mapserver
 set gdal-tag=%gdal_dev_tag%
 
-cmd /C makepackage.bat
+rem cmd /C makepackage.bat
 
 :stable
 

--- a/makevc12x64.bat
+++ b/makevc12x64.bat
@@ -146,7 +146,7 @@ set msautotest-dir=msautotest
 set pkg-version=gdal-mapserver
 set gdal-tag=%gdal_dev_tag%
 
-cmd /C makepackage.bat
+rem cmd /C makepackage.bat
 
 :stable
 


### PR DESCRIPTION
Only VS 2015 or above is supported for GDAL trunk