### PR TITLE
Makefile: install sqlite3ext.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2248,6 +2248,7 @@ $(SQLITE_LIB): $(CURL_EXE) $(MSVCRT_DLL)
     xcopy /Y *.exe $(OUTPUT_DIR)\bin
     xcopy /Y *.lib $(OUTPUT_DIR)\lib
     xcopy /Y sqlite3.h $(OUTPUT_DIR)\include
+    xcopy /Y sqlite3ext.h $(OUTPUT_DIR)\include
     copy /Y fts5*.h $(OUTPUT_DIR)\include
     copy /Y $(SQLITE_LIB) $(OUTPUT_DIR)\lib\sqlite3_i.lib
 !ENDIF


### PR DESCRIPTION
@szekerest I would like to get rid of GDAL's custom https://github.com/OSGeo/gdal/blob/master/ogr/ogrsf_frmts/sqlite/ogrsqlite3ext.h, hence installing this file
(hopefully my change will work. I didn't test)