### PR TITLE
Disable compiler warnings for non-nullable strings

### DIFF
--- a/nuget/GdalConfiguration.cs.pp
+++ b/nuget/GdalConfiguration.cs.pp
@@ -35,6 +35,8 @@ using System.Runtime.InteropServices;
 using Gdal = OSGeo.GDAL.Gdal;
 using Ogr = OSGeo.OGR.Ogr;
 
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+
 namespace $rootnamespace$
 {
     public static partial class GdalConfiguration


### PR DESCRIPTION
When adding the nuget package to a project with nullable reference types enabled, the [three null string assignments](https://github.com/Mbucari/buildsystem/blob/29ea78545865a82860a6ae6310f3e3294a8b3f89/nuget/GdalConfiguration.cs.pp#L62) cause analyzer warnings. Since you're targeting netstandard2.0 which only supports C# 7.3, you can't add a `#nullable disable` statement to GdalConfiguration.cs. So the only option remaining is to just disable that waning in the source file.

Nullable reference types is only available in C#, not VB.NET